### PR TITLE
Fix apply_filters() parameters in get_fallback_url()

### DIFF
--- a/local-gravatars.php
+++ b/local-gravatars.php
@@ -337,6 +337,6 @@ class LocalGravatars {
 	 * @return string
 	 */
 	public function get_fallback_url() {
-		return apply_filters( 'get_local_gravatars_fallback_url', '', $this->remote_url );
+		return apply_filters( 'get_local_gravatars_fallback_url', $this->remote_url );
 	}
 }


### PR DESCRIPTION
The second argument passed to `apply_filters()` should be the value being modified by the filter. https://developer.wordpress.org/reference/functions/apply_filters/

This issue was reported here: https://wordpress.org/support/topic/filter-for-get_local_gravatars_fallback_url-functional/

This PR fixes the following issue:

- The `get_fallback_url()` function returns an empty string by default instead of `$this->remote_url`