### PR TITLE
Improve GitHub and WordPress.org plugin copy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to Local Gravatars
+
+Thanks for your interest in improving Local Gravatars.
+
+## Before you start
+
+- Check existing issues and pull requests before opening a new one.
+- For security issues, please do **not** open a public issue. See [SECURITY.md](SECURITY.md).
+- Keep changes focused. Small, targeted pull requests are easier to review and merge.
+
+## Local development
+
+1. Clone the repository.
+2. Put the plugin in your local WordPress installation's `wp-content/plugins/` directory.
+3. Activate **Local Gravatars**.
+4. Test avatar output on pages that use `get_avatar()`.
+
+## What to include in a pull request
+
+Please include:
+
+- a clear summary of the change
+- why the change is needed
+- any relevant screenshots or output if behavior changes
+- testing notes, especially around avatar URLs, fallback behavior, and cleanup
+
+## Coding expectations
+
+- Follow WordPress coding standards.
+- Keep the plugin lightweight and easy to read.
+- Preserve backwards compatibility where possible.
+- Avoid adding UI or settings unless there is a strong product reason.
+- When adding filters or hooks, document them clearly.
+
+## Good contribution ideas
+
+- bug fixes and compatibility improvements
+- performance or filesystem safety improvements
+- documentation improvements
+- better test coverage or reproducible bug reports
+
+Thanks for helping make Local Gravatars better.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,98 @@
+# Local Gravatars
+
+[![GitHub release](https://img.shields.io/github/v/release/ProgressPlanner/local-gravatars?label=release)](https://github.com/ProgressPlanner/local-gravatars/releases)
+[![License](https://img.shields.io/github/license/ProgressPlanner/local-gravatars)](LICENSE)
+[![WordPress](https://img.shields.io/badge/WordPress-plugin-21759b?logo=wordpress&logoColor=white)](https://wordpress.org/plugins/)
+[![Privacy](https://img.shields.io/badge/focus-privacy-success)](#why-local-gravatars)
+
+**Serve Gravatar images from your own WordPress site instead of loading them directly from Gravatar.**
+
+Local Gravatars downloads remote Gravatar images, stores them on your site, and rewrites avatar URLs so visitors load them from your own domain. That reduces third-party requests, improves privacy, and can improve performance.
+
+## Why Local Gravatars?
+
+By default, WordPress avatars often load from Gravatar's infrastructure. That means every avatar request can reveal visitor IP addresses and browsing context to a third party.
+
+Local Gravatars helps by:
+
+- serving avatars from your own site URL
+- reducing external requests to Gravatar/CDN endpoints
+- improving privacy for logged-in users and visitors
+- keeping the implementation lightweight and easy to customize
+- automatically clearing cached avatar files on a schedule so images can refresh over time
+
+## How it works
+
+1. WordPress generates an avatar URL.
+2. Local Gravatars checks whether it is a valid Gravatar URL.
+3. The image is downloaded and stored locally in your `wp-content/gravatars` directory.
+4. The avatar HTML is updated to use the local file instead of the remote URL.
+5. A scheduled cleanup removes cached files regularly so avatars can be refreshed.
+
+## Installation
+
+### From the WordPress admin
+
+1. Go to **Plugins → Add New**.
+2. Search for **Local Gravatars**.
+3. Install and activate the plugin.
+
+### Manual installation
+
+1. Download this repository as a ZIP.
+2. Upload it to `/wp-content/plugins/`.
+3. Activate **Local Gravatars** in **Plugins → Installed Plugins**.
+
+## Usage
+
+Activate the plugin and keep using WordPress avatars as usual. No extra configuration is required.
+
+When avatars are requested, the plugin will start caching Gravatar images locally and serve them from your own site.
+
+## Available filters
+
+The plugin includes filters for developers who want to change its behavior:
+
+| Filter | Purpose |
+| --- | --- |
+| `get_local_gravatars_base_path` | Change where avatar files are stored on disk. |
+| `get_local_gravatars_base_url` | Change the public URL used for local avatar files. |
+| `get_local_gravatars_cleanup_frequency` | Change how often cached files are removed. |
+| `get_local_gravatars_max_process_time` | Change the max processing time before the plugin stops downloading more avatars in the current request. |
+| `get_local_gravatars_fallback_url` | Change the fallback image URL when a local copy cannot be used. |
+| `local_gravatars_is_valid_url` | Extend or restrict which remote avatar URLs are treated as valid. |
+
+## FAQ
+
+### Does this stop Gravatar from being used completely?
+
+It stops the browser from loading avatar images directly from Gravatar once a local copy is available. If a file has not been cached yet, the plugin may still need to fetch it first.
+
+### Where are avatars stored?
+
+By default, cached avatars are stored in `wp-content/gravatars`.
+
+### Will cached avatars update automatically?
+
+Yes. The plugin schedules cleanup of the local avatar folder so cached files are removed and can be downloaded again later.
+
+### Can I customize the storage location or cleanup schedule?
+
+Yes. The plugin exposes filters for the storage path, public URL, cleanup frequency, max processing time, and fallback image.
+
+## Who is this for?
+
+Local Gravatars is a good fit for:
+
+- privacy-conscious WordPress site owners
+- sites trying to reduce third-party requests
+- agencies and developers building more privacy-friendly WordPress stacks
+- site owners who want a simple, low-maintenance avatar caching solution
+
+## Contributing
+
+Issues and pull requests are welcome. If you plan to change behavior, improve compatibility, or add hooks, please open an issue or PR in this repository.
+
+## License
+
+Local Gravatars is licensed under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the latest maintained version of Local Gravatars.
+
+## Reporting a vulnerability
+
+Please do **not** report security vulnerabilities through public GitHub issues.
+
+Instead, report them privately to the maintainers through GitHub's private vulnerability reporting for this repository, or through the maintainer contact method listed in the repository settings.
+
+When reporting an issue, include:
+
+- a clear description of the vulnerability
+- steps to reproduce it
+- affected versions
+- impact assessment if known
+
+## Response expectations
+
+Maintainers should acknowledge valid reports as quickly as possible and work toward a fix before public disclosure.
+
+Please avoid publishing details until a fix or mitigation is available.

--- a/local-gravatars.php
+++ b/local-gravatars.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Plugin Name: Local Gravatars
- * Plugin URI: https://github.com/aristath/local-gravatars
- * Description: Locally host gravatars - for the privacy conscious
+ * Plugin URI: https://github.com/ProgressPlanner/local-gravatars
+ * Description: Host Gravatar images locally for better privacy and performance.
  * Requires at least: 5.3
  * Requires PHP: 7.4
  * Version: 1.1.3

--- a/readme.txt
+++ b/readme.txt
@@ -3,26 +3,74 @@ Contributors: aristath
 Requires at least: 5.5
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.1.2
+Stable tag: 1.1.3
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
-Locally host gravatars for the privacy-concious.
+Host Gravatar images locally in WordPress for better privacy, fewer third-party requests, and faster avatar delivery.
 
 == Description ==
 
-Allow your users to use gravatars, but without sacrificing privacy.
+Local Gravatars lets you keep using WordPress avatars while serving the image files from your own site instead of directly from Gravatar.
 
-The plugin will get your users gravatars and host them locally on your website.
-Your visitors will get the gravatars directly from your website instead of the gravatar CDN, therefore increasing privacy and performance.
+When an avatar is requested, the plugin downloads the Gravatar image, stores it locally, and rewrites the avatar URL so visitors load it from your own domain. That helps reduce third-party requests, improves privacy, and can improve performance.
 
-To avoid cluttering the filesystem and to allow refreshing gravatars, the files get flushed on a weekly basis (interval can be modified using a filter).
-To avoid performance issues server-side, the download process for gravatars is limited to a maximum of 5 seconds (value can be modified using a filter).
+= Why site owners use Local Gravatars =
 
-The code is simple, easy to read, well-documented and includes filters you can use to modify the behavior of the plugin:
+* Reduce direct browser requests to Gravatar.
+* Improve visitor privacy by serving avatar files from your own domain.
+* Lower dependency on external avatar/CDN requests.
+* Keep setup simple: activate the plugin and it starts working.
+* Refresh cached avatar files automatically with scheduled cleanup.
 
-* Changing the folder where gravatars get downloaded.
-* Change the URL of downloaded gravatars.
-* Change the cleanup frequency.
-* Change the maximum process time to avoid performance issues.
-* Change the fallback image to use (defaults to blank) - also allows using the remote URL (not recommended as it will defeat the purpose of this privacy enhancement).
+= Developer-friendly by design =
+
+The plugin is intentionally lightweight, readable, and easy to customize.
+
+Available filters:
+
+* `get_local_gravatars_base_path` — change where avatar files are stored.
+* `get_local_gravatars_base_url` — change the public URL used for local avatar files.
+* `get_local_gravatars_cleanup_frequency` — change how often cached files are removed.
+* `get_local_gravatars_max_process_time` — change how long processing can run during a request.
+* `get_local_gravatars_fallback_url` — set a fallback image URL.
+* `local_gravatars_is_valid_url` — extend or restrict which remote avatar URLs are accepted.
+
+== Installation ==
+
+1. Install and activate **Local Gravatars**.
+2. Keep using WordPress avatars as usual.
+3. The plugin will automatically cache Gravatar images locally as they are requested.
+
+== Frequently Asked Questions ==
+
+= Does this disable Gravatar completely? =
+
+It prevents browsers from loading cached avatar images directly from Gravatar. If an avatar has not been cached yet, the plugin may need to fetch it once before serving it locally.
+
+= Where are avatar files stored? =
+
+By default, files are stored in the `wp-content/gravatars` directory.
+
+= Do cached avatars refresh? =
+
+Yes. The plugin schedules regular cleanup so cached avatar files are removed and can be downloaded again later.
+
+= Can I change the storage location or timing? =
+
+Yes. Use the provided filters to change the storage path, public URL, cleanup frequency, processing time, and fallback image behavior.
+
+= Is there any configuration screen? =
+
+No. The plugin is designed to work out of the box with no settings page.
+
+== Changelog ==
+
+= 1.1.3 =
+* Improve avatar file handling and extension detection.
+* Add stricter validation for remote Gravatar URLs.
+* Improve initialization and file lookup performance.
+* Keep the codebase lightweight and easier to maintain.
+
+= 1.1.2 =
+* Previous release improvements.


### PR DESCRIPTION
## Summary
- add a stronger GitHub README and improve the WordPress.org readme
- improve plugin metadata and trust/community docs
- tighten privacy/performance-focused positioning

## Testing
- not needed (copy and metadata/docs only)