### PR TITLE
Add baseline GitHub Actions checks

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -1,0 +1,35 @@
+name: PHP Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: php-parallel-lint
+          coverage: none
+
+      - name: Lint PHP files
+        run: parallel-lint .

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -28,7 +28,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: php-parallel-lint
+          tools: parallel-lint
           coverage: none
 
       - name: Lint PHP files

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -1,0 +1,21 @@
+name: Playground Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Playground Preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Playground preview
+        uses: WordPress/action-wp-playground-pr-preview@v2
+        with:
+          plugin-path: .
+          mode: append-to-description
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -2,7 +2,7 @@ name: Playground Preview
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -17,5 +17,5 @@ jobs:
         uses: WordPress/action-wp-playground-pr-preview@v2
         with:
           plugin-path: .
-          mode: append-to-description
+          mode: comment
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wpcs.yml
+++ b/.github/workflows/wpcs.yml
@@ -1,0 +1,29 @@
+name: WordPress Coding Standards
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  phpcs:
+    name: WPCS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: WPCS check
+        uses: 10up/wpcs-action@stable
+        with:
+          enable_warnings: true
+          standard: WordPress
+          only_changed_lines: true

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "progressplanner/local-gravatars",
+    "description": "Locally host gravatars - for the privacy conscious.",
+    "type": "wordpress-plugin",
+    "homepage": "https://github.com/ProgressPlanner/local-gravatars",
+    "license": "MIT",
+    "require": {
+        "php": ">=7.4"
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true
+    }
+}


### PR DESCRIPTION
## Summary
- add WordPress coding standards checks
- add PHP linting across supported PHP versions
- add a Playground PR preview workflow

## Why
This plugin had no CI yet. These workflows add low-maintenance quality checks and an easy way to preview PRs.